### PR TITLE
removed var_dump after GET requests

### DIFF
--- a/lib/Beyonic/Beyonic.php
+++ b/lib/Beyonic/Beyonic.php
@@ -82,7 +82,6 @@ class Beyonic {
       					foreach($parameters as $key=>$value) {
       						$requestURL .= $key . "=" . urlencode($value) . "&";
       					}
-      					var_dump($requestURL);
       				  }
       		          break;
       case 'POST':    curl_setopt($ch, CURLOPT_POST, 1);


### PR DESCRIPTION
Removed `var_dump($requestURL);` code because it invalidates JSON responses for GET requests 